### PR TITLE
update headless guardrails for PyQt6 (PySide6 → PyQt6)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,7 +118,7 @@ grdl-runtime depends on grdl. grdl does **not** depend on grdl-runtime. All fram
 
 ### No GUI Dependencies
 
-grdl-runtime must run headless. No Qt, no PySide6, no display requirements. All visualization and GUI concerns belong in grdk.
+grdl-runtime must run headless. No Qt, no PyQt6, no display requirements. All visualization and GUI concerns belong in grdk.
 
 ### Graceful GRDL Fallbacks
 

--- a/tests/test_headless.py
+++ b/tests/test_headless.py
@@ -3,7 +3,7 @@
 Tests for headless guarantee — no GUI framework imports in grdl_rt/.
 
 Ensures that the grdl-runtime package can be used in headless server
-environments without requiring PySide6, Orange, napari, or any other
+environments without requiring PyQt6, Orange, napari, or any other
 GUI framework.
 
 Author
@@ -20,6 +20,7 @@ from pathlib import Path
 
 # Forbidden GUI framework tokens
 FORBIDDEN_GUI_TOKENS = [
+    "PyQt6",
     "PySide6",
     "from orange",
     "import orange",

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -45,5 +45,5 @@ class TestNoGuiDependencies:
         import grdl_rt
 
         source = inspect.getsource(grdl_rt)
-        for forbidden in ("PySide6", "orange", "napari", "QWidget", "QApplication"):
+        for forbidden in ("PyQt6", "PySide6", "orange", "napari", "QWidget", "QApplication"):
             assert forbidden not in source, f"Found forbidden GUI reference: {forbidden}"


### PR DESCRIPTION
grdk switched Qt backend to PyQt6. Update the no-GUI-dependency checks in CLAUDE.md and tests to forbid PyQt6 instead of only PySide6.